### PR TITLE
Update the Unicode mappings to reflect the decisions taken at UTC 179

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -44878,9 +44878,9 @@
 @list	LAK729
 @list	PTACE300
 @list	RSP136
-@uname	CUNEIFORM SIGN UN
-@list	U+12326
-@ucun	𒌦
+@uname	CUNEIFORM SIGN UN GUNU
+@list	U+12327
+@ucun	𒌧
 @uage	5.0
 @v	kalam
 @v	kalama
@@ -44888,19 +44888,19 @@
 @v	kanam
 @link eBL UN https://www.ebl.lmu.de/signs/UN
 @link Wikidata Q87556578 http://www.wikidata.org/entity/Q87556578
-@note The current state of OSL KALAM/KALAM@g is the first phase in
-      correcting the association of names and glyphs in Unicode 5.0.
-      The previous name of KALAM was UN and the previous name of KALAM@g
-      was UN@g. Further review of the various lists is necessary and
+@note The characters CUNEIFORM SIGN UN and CUNEIFORM SIGN UN GUNU are affected
+      by a glyph erratum incorporated into Unicode 16.0: the glyphs are swapped
+      with respect to Unicode 5.0..15.1, and a formal alias corrects the name of
+      UN GUNU to KALAM.  Further review of the various lists is necessary and
       most periods will need to treat KALAM and KALAM@g as a merger.
 @end sign
 
 @sign KALAM@g
 @oid	o0000575
 @list	LAK730
-@uname	CUNEIFORM SIGN UN GUNU
-@list	U+12327
-@ucun	𒌧
+@uname	CUNEIFORM SIGN UN
+@list	U+12326
+@ucun	𒌦
 @uage	5.0
 @v	kalamₓ
 @v	u₁₂


### PR DESCRIPTION
UN remains at U+12326, the glyphs are swapped, and U+12327 gets corrected to KALAM.

See the definition of the formal alias in https://github.com/unicode-org/unicodetools/pull/745 (this will be published as part of 16.0β).

See the UTC 179 minutes in [L2/24-061](https://www.unicode.org/cgi-bin/GetDocumentLink?L2/24-061) (to be published sometime next week).

See also https://www.unicode.org/L2/L2024/24074-cuneiform-un-kalam.pdf and https://www.unicode.org/L2/L2024/24068-script-wg-rept.pdf Section 5a.