### PR TITLE
Update about.xml to refer to UTR56 as an approved Unicode Technical Report rather than a Draft UTR

### DIFF
--- a/00web/about.xml
+++ b/00web/about.xml
@@ -46,14 +46,14 @@
 
       <esp:sh>OSL and Unicode</esp:sh>
 
-      <p>OSL is not part of the Unicode Standard or other Unicode
-      specification. However, it is recommended by a preliminary
-      document as the source of data such as sign values and
-      correspondences to other sign lists, which are in practice
-      needed to use the Unicode Sumero-Akkadian cuneiform characters.
-      See <esp:link url="https://www.unicode.org/reports/tr56/">Draft
-      Unicode Technical Report #56, “Unicode Cuneiform Sign
-      Lists”</esp:link>, edited by Robin Leroy.</p>
+      <p>OSL is not part of the Unicode Standard or any other Unicode
+      specification. However, it is recommended by a Unicode Technical Report as
+      the source of data such as sign values and correspondences to other sign
+      lists, which are in practice needed to use the Unicode Sumero-Akkadian
+      cuneiform characters.
+      See <esp:link url="https://www.unicode.org/reports/tr56/">Unicode
+      Technical Report #56, “Unicode Cuneiform Sign Lists”</esp:link>, edited by
+      Robin Leroy.</p>
             
       <esp:sh>OSL Licence</esp:sh>
 


### PR DESCRIPTION
See UTC decision and action item
[[179-C52](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-C52)] Consensus: Approve Draft UTR #56 for publication as Unicode Technical Report #56, Unicode Cuneiform Sign Lists. [Ref. Section 5b of document [L2/24-068](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-068)]
[[179-A152](https://www.unicode.org/cgi-bin/GetL2Ref.pl?179-A152)] Action Item for Robin Leroy, EDC: Shepherd the publication of UTR #56. [Ref. Section 5b of document [L2/24-068](https://www.unicode.org/cgi-bin/GetMatchingDocs.pl?L2/24-068)]
and see the newly published UTR at https://www.unicode.org/reports/tr56/tr56-3.html.