### PR TITLE
Split 𒎕 and 𒍴 from 𒂟 and 𒎎

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -6191,10 +6191,17 @@
 
 @sign DAG₃
 @oid	o0032005
+@list	MZL386
 @uname	CUNEIFORM SIGN DAG3
 @list	U+12374
 @ucun	𒍴
 @uage	7.0
+@v	dag₃
+@v	dak₃
+@v	daq₃
+@v	par₇
+@v	tak₃
+@v	taq₃
 @link eBL DAG₃ https://www.ebl.lmu.de/signs/DAG₃
 @link Wikidata Q87556748 http://www.wikidata.org/entity/Q87556748
 @end sign
@@ -31419,15 +31426,9 @@
 @v	%akk abnu
 @v	atumₓ
 @v	bar₄
-@v	dag₃
-@v	dak₃
-@v	daq₃
 @v	i₄
 @v	ia₄
 @v	na₄
-@v	par₇
-@v	tak₃
-@v	taq₃
 @v	ya₄
 @v	za₂
 @link Wikidata Q87556803 http://www.wikidata.org/entity/Q87556803

--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -9648,22 +9648,15 @@
 @list	U+1209F
 @ucun	𒂟
 @uage	5.0
-@v	%elx bir₃
 @v	erem
 @v	eren₂
 @v	erena₂
 @v	erim
 @v	erin₂
 @v	erina₂
-@v	hiš₃
-@v	lah₂
-@v	lih₂
 @v	nura
 @v	nuri
 @v	nuru
-@v	par₅
-@v	per₂
-@v	pir₂
 @v	rin₂
 @v	rina₂
 @v	sap₂
@@ -9673,8 +9666,6 @@
 @v	ṣap
 @v	ṣapa
 @v	%akk/n ṣābu
-@v	tam₅
-@v	udaₓ
 @v	zab
 @v	zalag₂
 @v	zap
@@ -34843,10 +34834,20 @@
 
 @sign PIR₂
 @oid	o0032009
+@list	MZL613
 @uname	CUNEIFORM SIGN PIR2
 @list	U+12395
 @ucun	𒎕
 @uage	7.0
+@v	%elx bir₃
+@v	hiš₃
+@v	lah₂
+@v	lih₂
+@v	par₅
+@v	per₂
+@v	pir₂
+@v	tam₅
+@v	udaₓ
 @link eBL PIR₂ https://www.ebl.lmu.de/signs/PIR₂
 @link Wikidata Q87556818 http://www.wikidata.org/entity/Q87556818
 @end sign


### PR DESCRIPTION
A year and a half ago, in #9, I mentioned that there remained two characters added in Unicode 7.0 that would require additional disunifications, but that I wanted to understand why they were disunified, which was not clear from MZL.

As is often the case, the older sign lists are more informative here: the reason is that 𒎕, while it looks identical to 𒂟 in NA, comes from 𒌓; and that 𒍴, while it looks identical to 𒎎, comes from 𒁖; see the snippets below.

These are not quite splits and mergers, since 𒌓 is pir whereas 𒎕 is pir₂, and 𒁖 is dag whereas 𒍴 is dag₃, so that the new values are in theory limited to the NA forms, but
1. since they are noncognate to 𒂟 and 𒎎, it seems sensible to split them;
2. it looks like Elamite transliterations tend to use pir₂ rather than pir for older texts where the sign looks like 𒌓, so that it really behaves like a split from 𒌓 and a merger with 𒂟 there, see, _e.g._, https://cdli.mpiwg-berlin.mpg.de/artifacts/215544.

|  | 𒎕 | 𒍴 |
|---|---|---|
| Le syllabaire accadien | ![image](https://github.com/oracc/osl/assets/2284290/75b7f6ca-4c34-47c2-878c-1146e0893bd1) | ![image](https://github.com/oracc/osl/assets/2284290/bfb6f889-1bf7-4839-86e5-5b703fa0dff1) |
| Das akkadische Syllabar | ![image](https://github.com/oracc/osl/assets/2284290/327e13ad-331d-4891-bdcc-af3829e80cb4) | ![image](https://github.com/oracc/osl/assets/2284290/410bf17c-a271-46f7-8809-875fc2e24b21) |
| Assyrisch-babylonische Zeichenliste | ![image](https://github.com/oracc/osl/assets/2284290/170c5406-2bfd-4327-9be1-166b2cb7ea2d) ![image](https://github.com/oracc/osl/assets/2284290/54504a61-2df8-48e5-b9ab-835c2b73b86d) | ![image](https://github.com/oracc/osl/assets/2284290/0d4d6a6e-832a-4f3b-bf76-e820a5879e19) ![image](https://github.com/oracc/osl/assets/2284290/988b5d85-fd7f-46f6-8b5b-35748f3e0542) ![image](https://github.com/oracc/osl/assets/2284290/993e406e-f893-4294-9f66-d5a777fb715c) |


