### PR TITLE
PTACE162 is 𒍡, not 𒆵.

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -9211,6 +9211,8 @@
 @sign ELLES396
 @oid	o0000172
 @list	ELLES396
+@list	LAK304a
+@list	PTACE162
 @uname	CUNEIFORM SIGN ZAMX
 @list	U+12361
 @ucun	𒍡
@@ -23613,7 +23615,6 @@
 @list	KWU794
 @list	LAK304
 @list	MZL896
-@list	PTACE162
 @list	SLLHA562
 @uname	CUNEIFORM SIGN KUSHU2
 @list	U+121B5
@@ -26590,13 +26591,6 @@
 @oid	o0000348
 @list	LAK298
 @link	eBL LAK298 https://www.ebl.lmu.de/signs/LAK298
-@end sign
-
-@sign LAK304a
-@oid	o0025835
-@list	LAK304a
-@inote	for dcclt/ebla--check that it is not in OGSL under a different name
-@v	zamₓ
 @end sign
 
 @sign LAK309a
@@ -45086,7 +45080,6 @@
 @link	Wikidata Q87556541 http://www.wikidata.org/entity/Q87556541
 @form KUŠU₂
 @oid	o0000295
-@list	PTACE162
 @link	eBL KUŠU₂ https://www.ebl.lmu.de/signs/KUŠU₂
 @@
 @form |UD×KUŠU₂|


### PR DESCRIPTION
See the email titled « Miscellaneous eblaite questions » (unfortunately I haven’t heard back from @erica-scarpa, but this one seems pretty clear and I’d rather do it before I forget).

Catagnoti calls PTACE162 KÚŠU and identifies it with LAK304, but lists only the value zamₓ.
ELLes distinguishes 𒍡 ZAMₓ=ELLes396 from 𒆵 KUŠU₂=ELLes175.
The drawing in PTACE162 resembles the ones in ELLes396 rather than those in ELLes175, and PTACE162 and ELLes396 are both [attested](https://oracc.museum.upenn.edu/dcclt?q=zamx) in an-zamₓ.
PTACE162 therefore seems to be ELLes396 rather than KUŠU₂. Conveniently, the name KUŠU₂ is not used in EbDA, so that should not lead to any compatibility issues on that front.
LAK304a was added in 03f471c6da8d5fd382b9ea8a7d40266777ca452c; it is unclear to me whether it is still needed, as I cannot find a LAK304a in dcclt/ebla; but it seems harmless to keep it, and it might also serve as a hint of the identification with LAK304 made in PTACE162.