### PR TITLE
Add missing ELLes numbers

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -24,7 +24,7 @@
 @lit	E. Burrows, Archaic Texts (UET 2; London 1935)
 @inote	To be added: Appendices I-III lettered signs as, e.g., BAU000I.A, BAU00II.A, BAU0III.A, etc.
 
-@listdef ELLES 1-397 006b 033a 033b 065a 195a 241a 244a 307b 317a 362a
+@listdef ELLES 1-32 34-397 006b 033a 033b 065a 195a 241a 244a 307b 317a 362a
 @lit	P. Mander, "Appendix E. Lista dei Segni dei testi lessicali di Ebla".
 	Pp. 285-382 in G. Pettinato, Testi Lessicali Monolingui della Biblioteca L. 2769 (MEE 3; Napoli 1981)
 
@@ -33645,6 +33645,9 @@
 
 @sign |NINDA₂×2(AŠ@c)|
 @oid	o0038269
+@list	ELLES058
+@ref	TCBI 1 32 = P382284 o ii 7, http://oracc.org/epsd2/P382284.20
+@ref	MEE 3 48 = P241498 o i 2, http://oracc.org/dcclt/ebla/P241498.5
 @v	saₓ
 @inote	epsd2/oakk; ebla; not in LAK 
 @end sign

--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -33094,8 +33094,13 @@
 @useq	x12252.x12038.x12038
 @ucun	𒉒𒀸𒀸
 @@
-@form |NINDA₂×(AŠ@c.AŠ@c)|
+@form |NINDA₂×2(AŠ@c)|
+@aka |NINDA₂×(AŠ@c.AŠ@c)|
 @oid	o0027880
+@list	ELLES058
+@ref	TCBI 1 32 = P382284 o ii 7, http://oracc.org/epsd2/P382284.20
+@ref	MEE 3 48 = P241498 o i 2, http://oracc.org/dcclt/ebla/P241498.5
+@inote	epsd2/oakk; ebla; not in LAK
 @@
 @end sign
 
@@ -33641,15 +33646,6 @@
 @sign |NINDA₂×3(AŠ)|
 @oid	o0028037
 @inote	gvl unknown compound
-@end sign
-
-@sign |NINDA₂×2(AŠ@c)|
-@oid	o0038269
-@list	ELLES058
-@ref	TCBI 1 32 = P382284 o ii 7, http://oracc.org/epsd2/P382284.20
-@ref	MEE 3 48 = P241498 o i 2, http://oracc.org/dcclt/ebla/P241498.5
-@v	saₓ
-@inote	epsd2/oakk; ebla; not in LAK 
 @end sign
 
 @sign |NINDA₂×3(AŠ@c)|

--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -24,7 +24,7 @@
 @lit	E. Burrows, Archaic Texts (UET 2; London 1935)
 @inote	To be added: Appendices I-III lettered signs as, e.g., BAU000I.A, BAU00II.A, BAU0III.A, etc.
 
-@listdef ELLES 1-32 34-397 006b 033a 033b 065a 195a 241a 244a 307b 317a 362a
+@listdef ELLES 1-32 34-158 160-397 006b 033a 033b 065a 159a 195a 208a 241^a 244^a 307b 317^a 363^a
 @lit	P. Mander, "Appendix E. Lista dei Segni dei testi lessicali di Ebla".
 	Pp. 285-382 in G. Pettinato, Testi Lessicali Monolingui della Biblioteca L. 2769 (MEE 3; Napoli 1981)
 
@@ -6491,7 +6491,8 @@
 
 @sign |DAG×PAP|
 @oid	o0031721
-@list	ELLES362a
+@list	ELLES363^a
+@ref	MEE 3 44 = P241092 o ix 11, http://oracc.org/dcclt/ebla/P241092
 @end sign
 
 @sign |DAG×U|
@@ -9981,7 +9982,7 @@
 @list	BAU143
 @list	BAU248
 @list	BAU413
-@list	ELLES159
+@list	ELLES159a
 @list	GCSL125
 @list	HZL327
 @list	KWU347
@@ -14599,7 +14600,7 @@
 @sign |GI₄%GI₄|
 @list	ASY177
 @oid	o0001408
-@list	ELLES244a
+@list	ELLES244^a
 @list	MZL508
 @list	SLLHA326a
 @list	SYA155
@@ -24054,7 +24055,7 @@
 @link	Wikidata Q87555867 http://www.wikidata.org/entity/Q87555867
 @form LAK461a
 @oid	o0025780
-@list	ELLES241a
+@list	ELLES241^a
 @list	LAK461a
 @inote	curviform LAK461; cuneiform LAK461 is unmarked LAK641
 @@
@@ -24169,6 +24170,7 @@
 @@
 @form |LAK526.MUŠ₃|
 @oid	o0031670
+@list	ELLES175a
 @inote	addx dcclt/ebla
 @useq	xF0073.x12239
 @ucun	󰁳𒈹
@@ -43778,6 +43780,10 @@
 @sys	Attinger maru⁻
 @link	eBL TE https://www.ebl.lmu.de/signs/TE
 @@
+@form |HI×GAN₂@t|
+@list	ELLES208a
+@ref	MEE 3 44 = P241092 o v 12, http://oracc.org/dcclt/ebla/P241092
+@@
 @end sign
 
 @sign |TE@g.AB@g|
@@ -47728,7 +47734,7 @@
 @form |URU×MIN+AŠ|
 @oid	o0031751
 @aka	|GIŠGAL+AŠ|
-@list	ELLES317a
+@list	ELLES317^a
 @inote	See drawing by Pettinato MEE 4 p97 ad r III 8 and ELLES318a
 @useq	x12347.x12038
 @ucun	𒍇𒀸

--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -24,7 +24,7 @@
 @lit	E. Burrows, Archaic Texts (UET 2; London 1935)
 @inote	To be added: Appendices I-III lettered signs as, e.g., BAU000I.A, BAU00II.A, BAU0III.A, etc.
 
-@listdef ELLES 1-32 34-158 160-397 006b 033a 033b 065a 159a 195a 208a 241^a 244^a 307b 317^a 363^a
+@listdef ELLES 1-32 34-158 160-397 006bis 033a 033b 065a 159a 175a 195a 208a 241^a 244^a 307b 317^a 363^a
 @lit	P. Mander, "Appendix E. Lista dei Segni dei testi lessicali di Ebla".
 	Pp. 285-382 in G. Pettinato, Testi Lessicali Monolingui della Biblioteca L. 2769 (MEE 3; Napoli 1981)
 
@@ -3149,7 +3149,7 @@
 @oid	o0000642
 @list	ABZL010
 @list	BAU008
-@list	ELLES006b
+@list	ELLES006bis
 @list	GCSL051
 @list	KWU025
 @list	LAK010
@@ -5005,7 +5005,7 @@
 @list	ASY095
 @oid	o0000642
 @list	BAU008
-@list	ELLES006b
+@list	ELLES006bis
 @list	GCSL051
 @list	KWU025
 @list	LAK010
@@ -42527,7 +42527,7 @@
 @list	ASY095
 @oid	o0000642
 @list	BAU008
-@list	ELLES006b
+@list	ELLES006bis
 @list	GCSL051
 @list	KWU025
 @list	LAK010


### PR DESCRIPTION
For some reason I had skipped ELLES058 in #12. While I was looking at that, I went over the list checking for ELLes numbers with alphabetic suffixes that were missing in OSL: ELLES208a, an ELLES208 missing a wedge, and ELLES175a.

I used the ^ notation from ba9e3b3813ec335e33e84795c7d0bccbbbb34d48 to distinguish suffixes introduced by OSL from those present in ELLes.

Note that there is no ELLES033, only ELLES033a and ELLES033b, and no ELLES159, only ELLES159a.