### PR TITLE
Fix the LAK and ELLes numbers for 𒌝 and 𒈩

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -30484,7 +30484,6 @@
 @end sign
 
 @sign MES
-@list	LAK127
 @list	ASY168
 @oid	o0000454
 @list	ABZL112a
@@ -30492,6 +30491,7 @@
 @list	ELLES071
 @list	GCSL260
 @list	HZL112
+@list	LAK607
 @list	MZL486
 @list	RSP277
 @list	SLLHA314
@@ -46630,6 +46630,7 @@
 @list	GCSL062
 @list	HZL098
 @list	KWU189
+@list	LAK127
 @list	MZL238
 @list	PTACE076
 @list	RSP274

--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -27711,13 +27711,6 @@
 @uage	9.2
 @end sign
 
-@sign LAK607
-@list	LAK607
-@oid	o0000401
-@list	ELLES298
-@link	eBL LAK607 https://www.ebl.lmu.de/signs/LAK607
-@end sign
-
 @sign LAK608
 @list	LAK608
 @oid	o0000402
@@ -30488,7 +30481,7 @@
 @oid	o0000454
 @list	ABZL112a
 @list	BAU077
-@list	ELLES071
+@list	ELLES298
 @list	GCSL260
 @list	HZL112
 @list	LAK607
@@ -46627,6 +46620,7 @@
 @list	ASY100
 @oid	o0000571
 @list	ABZL113
+@list	ELLES071
 @list	GCSL062
 @list	HZL098
 @list	KWU189


### PR DESCRIPTION
The NA column makes it clear that Deimel identifies LAK127 as UM, not MES; this is mostly consistent with modern readings of the citations:
- http://oracc.org/dcclt/P010566.264 ᵈUM-NUN (`{d}um-nun` in CDLI),
- http://oracc.org/epsd2/P220809.6 5(aš<sup>c</sup>) um-ma er₂
- http://oracc.org/epsd2/P220809.16.3 UM<sup>ki</sup>

LAK127 also cites (and copies) REC78, a sign from http://etcsri/Q001124.263; but that one seems to be a 𒄑+𒋛 ligature in addir rather than UM or MES (see the CDLI transliteration of http://cdli.earth/P222607, 11 11).

ELLES071 is identified by Mander with LAK127, so that number follows LAK127. Mander cites http://oracc.org/dcclt/P240986.46, http://oracc.org/dcclt/P218313.100, both um. He also cites http://oracc.org/dcclt/P241823, which is read mes in dcclt, but with a note that it is um in Pettinato. (If we wanted to get into those weeds perhaps we could add an ELLES071^a on MES…)

Likewise the NA column shows that Deimel identifies LAK607 as MES, and he cites http://oracc.org/dcclt/ebla/P010627 o 7 2, `kuš-MES`. Mander identifies ELLES298 with LAK607, so I am moving that number along with LAK607. I have not checked the citations in ELLES298.
